### PR TITLE
Add assertions in code

### DIFF
--- a/src/main/java/bin/task/Task.java
+++ b/src/main/java/bin/task/Task.java
@@ -10,6 +10,9 @@ public class Task {
     protected DateTimeFormatter stringFormat = DateTimeFormatter.ofPattern("d MMMM ha");
 
     public Task(Boolean isDone, String description) {
+        assert isDone != null : "isDone should not be null";
+        assert description != null : "description should not be null";
+
         this.description = description;
         this.isDone = isDone;
     }
@@ -65,6 +68,8 @@ public class Task {
      * @return boolean whether description contains keyword.
      */
     public boolean contains(String keyword) {
+        assert keyword != null : "Keyword should not be null";
+
         return this.description.contains(keyword);
     }
 }

--- a/src/main/java/bin/ui/Bin.java
+++ b/src/main/java/bin/ui/Bin.java
@@ -11,6 +11,7 @@ public class Bin {
     private TaskList tasks;
 
     public Bin(String filePath) {
+        assert filePath != null : "File path must not be null";
         storage = new Storage(filePath);
         try {
             tasks = new TaskList(storage.load());
@@ -20,6 +21,8 @@ public class Bin {
     }
 
     public String getResponse(String command) {
+        assert tasks != null : "Task list should have been initialized";
+        assert command != null : "Command input should not be null";
         Parser parser = new Parser(command, this.tasks);
         storage.save(tasks);
         return parser.parseCommand();


### PR DESCRIPTION
Task and Bin: add assertions to enforce non-null inputs.

The Task and Bin classes assume that certain inputs, such as the task description, command strings, and file paths, are non-null. However, these assumptions are implicit and not enforced in code, which can lead to NullPointerExceptions if violated.

Let's add assertions in the Task constructor, and the Bin constructor and `getResponse()` method to explicitly check for non-null inputs.

These assertions help document developer expectations and catch bugs early during testing and development, without impacting production behavior when assertions are disabled.